### PR TITLE
fix: missing type file in publish config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "dist/SPHclient.js",
   "typings": "dist/SPHclient.d.ts",
   "files": [
-    "SPHclient.js",
-    "SPHclient.d.js",
+    "dist/",
     "readme.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Follow up to #8 because I missed some publish config

(The Typescript definition file wasn't included, this should fix it. Now the complete folder will be published, so in the future this issue should not appear anymore)

I'm Sorry 